### PR TITLE
Add FHIR connector with plugin framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm ci
+RUN npm ci && npm install fhir-kit-client
 
 # Set a build-time argument for OLLAMA_URL with a default value
 ARG OLLAMA_URL=http://127.0.0.1:11434
@@ -29,6 +29,8 @@ COPY --from=builder /app/node_modules ./node_modules
 # Set environment variable with a default value that can be overridden at runtime
 ENV OLLAMA_URL=http://127.0.0.1:11434
 ENV PORT=3000
+
+RUN mkdir -p /app/logs /app/cache
 
 EXPOSE 3000
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.8",
@@ -38,6 +39,7 @@
     "@tanstack/react-query": "^5.66.0",
     "@types/dom-speech-recognition": "^0.0.4",
     "ai": "^4.1.16",
+    "fhir-kit-client": "^4.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "emoji-mart": "^5.6.0",
@@ -83,6 +85,8 @@
     "pino-pretty": "^13.0.0",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^1.5.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+/// Run `npx prisma migrate dev --name init` after editing this schema
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model FhirRecord {
+  id        Int      @id @default(autoincrement())
+  resource  Json
+  createdAt DateTime @default(now())
+}

--- a/scripts/ingest-fhir.ts
+++ b/scripts/ingest-fhir.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env ts-node
+import fs from 'fs'
+import path from 'path'
+import { FhirLoader } from '../src/connectors/fhirLoader'
+import { chunkFhirResource } from '../src/lib/chunking/fhirChunker'
+import { ensureDir } from '../src/lib/fs'
+
+async function main() {
+  const loader = new FhirLoader({ resourceType: 'Patient' })
+  await loader.connect()
+  const cache = path.join('cache', 'fhir')
+  ensureDir(cache)
+  for await (const res of loader.load()) {
+    for (const chunk of chunkFhirResource(res as Record<string, any>)) {
+      const file = path.join(cache, `${chunk.id}.json`)
+      fs.writeFileSync(file, JSON.stringify(chunk))
+    }
+  }
+}
+
+main().catch(err => {
+  ensureDir('logs')
+  fs.appendFileSync(path.join('logs', 'ingest-fhir.err'), String(err) + '\n')
+})

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { displayResults } from "./tools/displayResults";
 import { queryDatabase } from "./tools/queryDatabase";
 import { SYSTEM_PROMPT } from './prompts';
 import { selectTable } from './tools/selectTable';
+import { fhir_query } from '@/tools';
 
 export const maxDuration = 30;
 
@@ -32,6 +33,7 @@ export async function POST(req: Request) {
       selectTable,
       queryDatabase,
       displayResults,
+      fhir_query,
     };
 
     const result = streamText({

--- a/src/components/chat/ConnectDialog.tsx
+++ b/src/components/chat/ConnectDialog.tsx
@@ -117,6 +117,18 @@ export function AddDatabaseDialog() {
               Elastic Search
             </Button>
 
+            {/* FHIR */}
+            <Button variant="ghost" className="w-full justify-start py-4">
+              <Image
+                src="/fhir.svg"
+                alt="FHIR"
+                width={30}
+                height={30}
+                className="mr-2"
+              />
+              FHIR Server
+            </Button>
+
             {/* Custom */}
             <Button variant="ghost" className="w-full justify-start py-4">
               <Image

--- a/src/connectors/base.ts
+++ b/src/connectors/base.ts
@@ -1,0 +1,7 @@
+export abstract class Connector<TOptions = unknown> {
+  constructor(public options: TOptions) {}
+  /** Establish a connection to the source system. */
+  abstract connect(): Promise<void>
+  /** Load data from the source system. */
+  abstract load(): AsyncGenerator<unknown>
+}

--- a/src/connectors/fhirLoader.ts
+++ b/src/connectors/fhirLoader.ts
@@ -1,0 +1,52 @@
+import Client from 'fhir-kit-client'
+import { Connector } from './base'
+import fs from 'fs'
+import path from 'path'
+import { ensureDir } from '@/lib/fs'
+
+export interface FhirLoaderOptions {
+  resourceType: string
+  query?: Record<string, string>
+}
+
+export class FhirLoader extends Connector<FhirLoaderOptions> {
+  private client: Client
+
+  constructor(options: FhirLoaderOptions) {
+    super(options)
+    this.client = new Client({
+      baseUrl: process.env.FHIR_BASE_URL || '',
+      auth: {
+        username: process.env.FHIR_USERNAME || '',
+        password: process.env.FHIR_PASSWORD || ''
+      }
+    })
+  }
+
+  async connect(): Promise<void> {
+    try {
+      await this.client.capabilityStatement()
+    } catch (err) {
+      ensureDir('logs')
+      fs.appendFileSync(path.join('logs', 'fhirLoader.err'), String(err) + '\n')
+      throw err
+    }
+  }
+
+  async *load(): AsyncGenerator<unknown> {
+    const count = Number(process.env.FHIR_PAGE_SIZE || '50')
+    let bundle = await this.client.search({
+      resourceType: this.options.resourceType,
+      searchParams: { ...(this.options.query || {}), _count: count }
+    })
+
+    while (bundle) {
+      for (const entry of bundle.entry || []) {
+        yield entry.resource
+      }
+      const next = bundle.link?.find(l => l.relation === 'next')?.url
+      if (!next) break
+      bundle = await this.client.request(next)
+    }
+  }
+}

--- a/src/connectors/postgresLoader.ts
+++ b/src/connectors/postgresLoader.ts
@@ -1,0 +1,21 @@
+import postgres from 'postgres'
+import { Connector } from './base'
+
+export interface PostgresLoaderOptions {
+  query: string
+}
+
+export class PostgresLoader extends Connector<PostgresLoaderOptions> {
+  private sql = postgres(process.env.DATABASE_URL || '')
+
+  async connect(): Promise<void> {
+    await this.sql`select 1` // simple ping
+  }
+
+  async *load(): AsyncGenerator<unknown> {
+    const rows = await this.sql.unsafe(this.options.query)
+    for (const row of rows) {
+      yield row
+    }
+  }
+}

--- a/src/lib/chunking/fhirChunker.ts
+++ b/src/lib/chunking/fhirChunker.ts
@@ -1,0 +1,14 @@
+export interface FhirChunk {
+  id: string
+  text: string
+}
+
+/** Convert a FHIR resource into text chunks. */
+export function chunkFhirResource(resource: Record<string, any>, size = 1000): FhirChunk[] {
+  const payload = JSON.stringify(resource)
+  const chunks: FhirChunk[] = []
+  for (let i = 0; i < payload.length; i += size) {
+    chunks.push({ id: `${resource.id || 'unknown'}-${i / size}`, text: payload.slice(i, i + size) })
+  }
+  return chunks
+}

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+function logError(name: string, err: unknown) {
+  try {
+    const dir = path.join('.', 'logs')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.appendFileSync(path.join(dir, `${name}.err`), String(err) + '\n')
+  } catch {}
+}
+
+/** Ensure that a directory exists. */
+export function ensureDir(dir: string): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+  } catch (err) {
+    logError('ensureDir', err)
+  }
+}
+
+/** Ensure that a file exists, creating parent directories if needed. */
+export function ensureFile(file: string): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    if (!fs.existsSync(file)) fs.writeFileSync(file, '')
+  } catch (err) {
+    logError('ensureFile', err)
+  }
+}

--- a/src/retrievers/fhir.ts
+++ b/src/retrievers/fhir.ts
@@ -1,0 +1,12 @@
+import { FhirLoader } from '@/connectors/fhirLoader'
+import { chunkFhirResource } from '@/lib/chunking/fhirChunker'
+
+export async function retrieveFhir(resourceType: string, query: Record<string, string> = {}) {
+  const loader = new FhirLoader({ resourceType, query })
+  await loader.connect()
+  const chunks = [] as ReturnType<typeof chunkFhirResource>
+  for await (const res of loader.load()) {
+    chunks.push(...chunkFhirResource(res as Record<string, any>))
+  }
+  return chunks
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,15 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import { retrieveFhir } from '@/retrievers/fhir'
+
+export const fhir_query = tool({
+  description: 'Query resources from the connected FHIR server.',
+  parameters: z.object({
+    resourceType: z.string(),
+    query: z.record(z.string(), z.string()).optional()
+  }),
+  execute: async ({ resourceType, query }) => {
+    const res = await retrieveFhir(resourceType, query ?? {})
+    return JSON.stringify(res)
+  }
+})

--- a/tests/connectors.test.ts
+++ b/tests/connectors.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('fhir-kit-client', () => {
+  return { default: class { constructor(public opts:any){} capabilityStatement=vi.fn().mockResolvedValue({}); search=vi.fn().mockResolvedValue({}); request=vi.fn()} }
+})
+
+import { FhirLoader } from '../src/connectors/fhirLoader'
+
+describe('FhirLoader', () => {
+  it('uses env vars for base url', async () => {
+    process.env.FHIR_BASE_URL = 'http://example.com'
+    const loader = new FhirLoader({ resourceType: 'Patient' })
+    await loader.connect()
+    expect((loader as any).client.opts.baseUrl).toBe('http://example.com')
+  })
+})

--- a/tests/fhirChunker.test.ts
+++ b/tests/fhirChunker.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { chunkFhirResource } from '../src/lib/chunking/fhirChunker'
+
+describe('chunkFhirResource', () => {
+  it('splits resource into chunks', () => {
+    const res = { id: '1', data: 'a'.repeat(2100) }
+    const chunks = chunkFhirResource(res, 1000)
+    expect(chunks.length).toBe(3)
+    expect(chunks[0].text.length).toBe(1000)
+  })
+})

--- a/tests/fs.test.ts
+++ b/tests/fs.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { ensureDir, ensureFile } from '../src/lib/fs'
+
+const tmpDir = path.join('cache', 'test-dir')
+const tmpFile = path.join(tmpDir, 'file.txt')
+
+describe('fs helpers', () => {
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('creates directories', () => {
+    ensureDir(tmpDir)
+    expect(fs.existsSync(tmpDir)).toBe(true)
+  })
+
+  it('creates files', () => {
+    ensureFile(tmpFile)
+    expect(fs.existsSync(tmpFile)).toBe(true)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/chat/SendToolExecutor.tsx", "src/lib/seed.mjs"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/chat/SendToolExecutor.tsx", "src/lib/seed.mjs", "types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/fhir-temp.d.ts
+++ b/types/fhir-temp.d.ts
@@ -1,0 +1,9 @@
+declare module 'fhir-kit-client' {
+  export default class Client {
+    constructor(options: any)
+    capabilityStatement(): Promise<any>
+    search(opts: any): Promise<any>
+    request(url: string): Promise<any>
+    [key: string]: any
+  }
+}


### PR DESCRIPTION
## Summary
- add fs helpers for bootstrapping directories and files
- introduce connector framework and PostgreSQL/FHIR loaders
- support FHIR queries as a tool and register it in chat API
- chunker, retriever, CLI ingest script and Prisma model for FHIR data
- update Connect dialog UI with FHIR option
- update Dockerfile for fhir-kit-client and runtime dirs
- add initial Vitest tests and type stubs

## Testing
- `npx vitest run --coverage` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_b_688d214459c883228bc25801b95498d6