### PR TITLE
Fix client imports of server connectors

### DIFF
--- a/src/app/api/credentials/route.ts
+++ b/src/app/api/credentials/route.ts
@@ -14,3 +14,9 @@ export async function POST(req: Request) {
   })
   return new Response('ok')
 }
+
+export async function GET() {
+  const secrets = await prisma.secrets.findMany({ select: { source: true } })
+  const names = Array.from(new Set(secrets.map((s) => s.source)))
+  return Response.json(names)
+}

--- a/src/components/chat/ConnectDialog.tsx
+++ b/src/components/chat/ConnectDialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -10,12 +10,23 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog'
-import { connectorRegistry } from '@/connectors/registry'
+import { connectorNames } from '@/connectors/names'
 
 /** Dialog to store connector credentials */
 export function AddDatabaseDialog() {
   const [connected, setConnected] = useState<Record<string, boolean>>({})
   const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/credentials')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((active: string[]) => {
+        const state: Record<string, boolean> = {}
+        for (const name of active) state[name] = true
+        setConnected(state)
+      })
+      .catch(() => {})
+  }, [])
 
   async function onConnect(e: React.FormEvent<HTMLFormElement>, name: string) {
     e.preventDefault()
@@ -43,7 +54,7 @@ export function AddDatabaseDialog() {
           <DialogTitle>Connectors</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          {Object.keys(connectorRegistry).map((name) => (
+          {connectorNames.map((name) => (
             <form key={name} onSubmit={(e) => onConnect(e, name)} className="border p-2 rounded">
               <p className="font-semibold mb-2">
                 {name} {connected[name] && <span className="text-green-500">Connected</span>}

--- a/src/connectors/names.ts
+++ b/src/connectors/names.ts
@@ -1,0 +1,2 @@
+export const connectorNames = ['postgres', 'fhir'] as const
+export type ConnectorName = typeof connectorNames[number]

--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -1,13 +1,16 @@
+'use server'
+
 import { Connector } from './base'
 import { PostgresLoader } from './postgresLoader'
 import { FhirLoader } from './fhirLoader'
 import { prisma } from '@/providers/prisma'
+import { connectorNames } from './names'
 
 /** Registry of available connectors */
-export const connectorRegistry = {
+export const connectorRegistry: Record<(typeof connectorNames)[number], Connector> = {
   postgres: new PostgresLoader('SELECT 1'),
   fhir: new FhirLoader('Patient')
-} satisfies Record<string, Connector>
+}
 
 /**
  * Return connectors that have saved credentials.


### PR DESCRIPTION
## Summary
- expose connector names separately from server-only logic
- ensure connector registry is server-side only
- update AddDatabaseDialog to fetch connector status via API
- implement GET in /api/credentials

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_b_688d375ab46c83228e67fef73ca3bb1f