### PR TITLE
Fix Prisma client build on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.0.0+sha512.b8fef5494bd3fe4cbd4edabd0745df2ee5be3e4b0b8b08fa643aa3e4c6702ccc0f00d68fa8a8c9858a735a0032485a44990ed2810526c875e416f001b17df12b",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "prisma"
+    ]
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- allow build scripts for `@prisma/client`, `@prisma/engines` and `prisma`

## Testing
- `pnpm test`
- `pnpm rebuild` *(fails to download Prisma engines because `binaries.prisma.sh` is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_688d3c6ee35483229ce0485a48b6e832