### PR TITLE
Fix prisma client generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.8",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,25 +1,26 @@
 // Run `npx prisma migrate dev --name init` after updating this schema
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [vector]
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 model FhirResource {
   id           Int      @id @default(autoincrement())
   resourceType String
   data         Json
-  embedding    Vector   @db.Vector(1536)
+  embedding    Json
   patientId    String?
   encounterId  String?
   createdAt    DateTime @default(now())
 
   @@index([patientId])
-  @@index([embedding])
 }
 
 model Secrets {


### PR DESCRIPTION
## Summary
- include vector extension in Prisma schema
- enable postgresqlExtensions preview
- store embeddings as JSON
- ensure Prisma client generates after install

## Testing
- `npm run lint`
- `npm test`
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_b_688d4267ae8c83228c457ec0a689b5e1