### PR TITLE
Fix build issue from server directive

### DIFF
--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -1,5 +1,3 @@
-'use server'
-
 import { Connector } from './base'
 import { PostgresLoader } from './postgresLoader'
 import { FhirLoader } from './fhirLoader'


### PR DESCRIPTION
## Summary
- remove obsolete 'use server' directive from connector registry

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_688d472dcf2883229dee4980324a0321