### PR TITLE
Fix Next.js build error due to postgres client imports

### DIFF
--- a/src/components/chat/ConnectDialog.tsx
+++ b/src/components/chat/ConnectDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog'
-import { connectorRegistry } from '@/connectors/registry'
+import { connectorNames } from '@/connectors/names'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -82,7 +82,7 @@ export function AddDatabaseDialog() {
           <DialogTitle>Connectors</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          {Object.keys(connectorRegistry).map((name) => (
+          {connectorNames.map((name) => (
             <ConnectorCard
               key={name}
               name={name}


### PR DESCRIPTION
## Summary
- avoid importing Node-only postgres connector into client dialog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688d52708fa48322859cb7099f2458a7