### PR TITLE
feat: add connector utilities and secure queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.8",
+    "@dqbd/tiktoken": "^1.0.21",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@emotion/react": "^11.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^1.1.8
         version: 1.1.8(zod@3.24.2)
+      '@dqbd/tiktoken':
+        specifier: ^1.0.21
+        version: 1.0.21
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -398,6 +401,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dqbd/tiktoken@1.0.21':
+    resolution: {integrity: sha512-grBxRSY9+/iBM205EWjbMm5ySeXQrhJyXWMP38VJd+pO2DRGraDAbi4n8J8T9M4XY1M/FHgonMcmu3J+KjcX0Q==}
 
   '@ecies/ciphers@0.2.2':
     resolution: {integrity: sha512-ylfGR7PyTd+Rm2PqQowG08BCKA22QuX8NzrL+LxAAvazN10DMwdJ2fWwAzRj05FI/M8vNFGm3cv9Wq/GFWCBLg==}
@@ -7459,6 +7465,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dqbd/tiktoken@1.0.21': {}
 
   '@ecies/ciphers@0.2.2(@noble/ciphers@1.2.1)':
     dependencies:

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -3,11 +3,11 @@ export const dynamic = "force-dynamic";
 
 
 import { ChatLayout } from "@/components/chat/chat-layout";
-import { generateUUID } from "@/lib/utils";
+import { uuid } from "@/lib/utils";
 import React from "react";
 
 export default function Home() {
-  const id = generateUUID();
+  const id = uuid();
 
   return (
     <main className="flex h-[calc(100dvh)] flex-col items-center ">

--- a/src/app/api/chat/tools/queryDatabase.ts
+++ b/src/app/api/chat/tools/queryDatabase.ts
@@ -6,17 +6,18 @@ import { sql } from "@/providers/db";
 export const queryDatabase = tool({
   description: QUERY_DB_TOOL_DESCRIPTION,
   parameters: z.object({
-    query: z.string().describe("SQL query to execute."),
+    table: z.string().describe("Table name"),
+    id: z.union([z.number(), z.string()]).describe("Row id"),
   }),
-  execute: async ({ query }) => {
-    console.log("QUERY:", query);
+  execute: async ({ table, id }) => {
+    console.log("QUERY:", table, id);
 
     try {
-      // Execute the raw SQL query using sql.unsafe()
-      const result = await sql.unsafe(query);
+      const result = await sql`SELECT * FROM ${sql(table)} WHERE id = ${id}`;
       return JSON.stringify({
-        query: query,
-        result: result, // returns an array of rows
+        table,
+        id,
+        result,
       });
     } catch (error) {
       console.error("Error executing query:", error);

--- a/src/connectors/postgresLoader.ts
+++ b/src/connectors/postgresLoader.ts
@@ -1,5 +1,5 @@
 import { sql } from '@/providers/db';
-import { generateUUID } from '@/lib/utils';
+import { uuid } from '@/lib/utils';
 import { Connector, Document } from './base';
 import { embedChunks } from '@/lib/embedChunks';
 import { prisma } from '@/providers/prisma';
@@ -15,7 +15,7 @@ export class PostgresLoader extends Connector {
   }
 
   async chunk(rows: any[]): Promise<Document[]> {
-    return rows.map((r) => ({ id: String(r.id ?? generateUUID()), text: JSON.stringify(r) }))
+    return rows.map((r) => ({ id: String(r.id ?? uuid()), text: JSON.stringify(r) }))
   }
 
   async embed(chunks: Document[]): Promise<number[][]> {
@@ -29,7 +29,7 @@ export class PostgresLoader extends Connector {
 
   async similar(question: string, k: number): Promise<any[]> {
     const [e] = await embedChunks([question])
-    return sql.unsafe('SELECT * FROM "FhirResource" ORDER BY embedding <-> $1 LIMIT $2', [e, k])
+    return sql`SELECT * FROM "FhirResource" ORDER BY embedding <-> ${e} LIMIT ${k}`
   }
 
   async connected(): Promise<boolean> {

--- a/src/hooks/connectorHooks.ts
+++ b/src/hooks/connectorHooks.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+import type { ConnectorName } from '@/connectors/names';
+import { api, fetcher } from '@/lib/api';
+
+export const useConnectorTest = (type: ConnectorName) => {
+  const [status, setStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle');
+  const [error, setError] = useState<string>();
+  const test = async (cfg: any) => {
+    setStatus('testing');
+    try {
+      await api.post(`/connectors/${type}/test`, cfg);
+      setStatus('ok');
+    } catch (e: any) {
+      setStatus('error');
+      setError(e.message);
+    }
+  };
+  return { status, error, test };
+};
+
+export const useSyncProgress = (connectorId: string) => {
+  const { data } = useSWR<{ percent: number }>(
+    `/connectors/${connectorId}/progress`,
+    fetcher,
+    { refreshInterval: 1000 }
+  );
+  return data?.percent ?? 0;
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,15 @@
+export const api = {
+  async post(url: string, body: any) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    return res.json();
+  },
+};
+
+export const fetcher = (url: string) => fetch(url).then((res) => res.json());

--- a/src/lib/chunking/fhirChunker.ts
+++ b/src/lib/chunking/fhirChunker.ts
@@ -1,4 +1,5 @@
 import { Document } from '@/connectors/base'
+import { encoding_for_model } from '@dqbd/tiktoken'
 
 export interface Chunk { id: string; text: string }
 
@@ -7,15 +8,21 @@ export function flattenBundle(bundle: any): any[] {
   return (bundle?.entry ?? []).map((e: any) => e.resource).filter(Boolean)
 }
 
+const enc = encoding_for_model('text-embedding-3-large')
+
 /**
- * Chunk a JSON object by stringifying and splitting every `size` characters.
+ * Chunk a JSON object ensuring each piece stays under `maxTokens` tokens.
  */
-export function chunkJSON(json: any, size = 500): Chunk[] {
+export function chunkJSON(json: any, maxTokens = 500): Chunk[] {
   const text = typeof json === 'string' ? json : JSON.stringify(json)
   const id = (json && (json.id || json.resourceType)) || 'unknown'
+  const tokens = enc.encode(text)
   const out: Chunk[] = []
-  for (let i = 0; i < text.length; i += size) {
-    out.push({ id, text: text.slice(i, i + size) })
+  for (let i = 0; i < tokens.length; i += maxTokens) {
+    const slice = tokens.slice(i, i + maxTokens)
+    const decoded = enc.decode(slice)
+    const textChunk = typeof decoded === 'string' ? decoded : new TextDecoder().decode(decoded)
+    out.push({ id, text: textChunk })
   }
   return out
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,10 +5,4 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
+export const uuid = () => crypto.randomUUID()

--- a/src/types/embedding.ts
+++ b/src/types/embedding.ts
@@ -1,0 +1,13 @@
+export interface EmbeddedRow {
+  id: string;
+  connectorId: string;
+  embedding: number[];
+  source: string; // "mongodb://.../users#123"
+  text: string;   // raw flattened JSON
+  updatedAt: Date;
+}
+
+export interface SearchResult {
+  row: EmbeddedRow;
+  score: number; // cosine similarity 0-1
+}

--- a/tests/fhirChunker.test.ts
+++ b/tests/fhirChunker.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { chunkJSON } from '../src/lib/chunking/fhirChunker';
+import { encoding_for_model } from '@dqbd/tiktoken';
 
 describe('fhirChunker', () => {
   it('splits json into chunks', () => {
+    const enc = encoding_for_model('text-embedding-3-large');
     const chunks = chunkJSON({ id: '1', foo: 'a'.repeat(25) }, 10);
     expect(chunks.length).toBeGreaterThan(0);
-    expect(chunks[0].text.length).toBeLessThanOrEqual(10);
+    const tokenCount = enc.encode(chunks[0].text).length;
+    expect(tokenCount).toBeLessThanOrEqual(10);
   });
 });


### PR DESCRIPTION
## Summary
- secure database querying with parameterized inputs
- expose `uuid` helper and connector hooks
- chunk FHIR JSON by token count using tiktoken

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_688d651071e4832294a36072cd8df678