### PR TITLE
feat: add Prisma client singleton

### DIFF
--- a/docs/PRISMA_CLIENT.md
+++ b/docs/PRISMA_CLIENT.md
@@ -1,0 +1,24 @@
+# Prisma Client Singleton
+
+This project uses a singleton instance of `PrismaClient` to avoid opening new
+connections every time the server reloads in development.
+
+```ts
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+```
+
+- In **development**, the instance is cached on `globalThis` so that hot
+  reloads reuse the existing connection.
+- In **production**, a new client is created for each serverless invocation
+  or process.
+
+When writing new code that accesses the database, always import `prisma` from
+`src/providers/prisma.ts` instead of instantiating a new `PrismaClient`.

--- a/src/providers/prisma.ts
+++ b/src/providers/prisma.ts
@@ -1,4 +1,16 @@
 import { PrismaClient } from '@prisma/client'
 
-/** Singleton Prisma client */
-export const prisma = new PrismaClient()
+/**
+ * Singleton Prisma client
+ *
+ * In development we store the Prisma client on `globalThis` to ensure that
+ * hot reloads reuse the same instance and do not create new database
+ * connections. In production a new client is created per invocation.
+ */
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}


### PR DESCRIPTION
## Summary
- cache Prisma client on `globalThis` in development to reuse connection across reloads
- document Prisma client singleton for contributors

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_688d7c1049108322bf666dd1ca863fd0