### PR TITLE
feat: add typed api post and fetcher error handling

### DIFF
--- a/src/hooks/connectorHooks.ts
+++ b/src/hooks/connectorHooks.ts
@@ -20,10 +20,13 @@ export const useConnectorTest = (type: ConnectorName) => {
 };
 
 export const useSyncProgress = (connectorId: string) => {
-  const { data } = useSWR<{ percent: number }>(
+  const { data, error } = useSWR<{ percent: number }>(
     `/connectors/${connectorId}/progress`,
     fetcher,
     { refreshInterval: 1000 }
   );
+  if (error) {
+    return 0;
+  }
   return data?.percent ?? 0;
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 export const api = {
-  async post(url: string, body: any) {
+  async post<T>(url: string, body: unknown): Promise<T> {
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -8,8 +8,14 @@ export const api = {
     if (!res.ok) {
       throw new Error(await res.text());
     }
-    return res.json();
+    return res.json() as Promise<T>;
   },
 };
 
-export const fetcher = (url: string) => fetch(url).then((res) => res.json());
+export const fetcher = async <T>(url: string): Promise<T> => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json() as Promise<T>;
+};


### PR DESCRIPTION
## Summary
- make `api.post` generic with typed responses
- check `res.ok` in `fetcher` and throw on failure
- handle fetch errors in `useSyncProgress`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_688d7c1053b08322a389c9cff155e8e7