### PR TITLE
chore: validate OLLAMA_URL in tags API

### DIFF
--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -3,9 +3,12 @@ export const revalidate = 0;
 
 export async function GET(req: Request) {
   const OLLAMA_URL = process.env.OLLAMA_URL;
-  console.log('OLLAMA_URL:', process.env.OLLAMA_URL);
-  const res = await fetch(
-    OLLAMA_URL + "/api/tags"
-  );
+  if (!OLLAMA_URL) {
+    console.error("[api/tags] Missing OLLAMA_URL environment variable");
+    return new Response("Missing OLLAMA_URL environment variable", { status: 500 });
+  }
+
+  // OLLAMA_URL should point to your running Ollama instance, e.g. http://127.0.0.1:11434
+  const res = await fetch(OLLAMA_URL + "/api/tags");
   return new Response(res.body, res);
 }


### PR DESCRIPTION
## Summary
- validate OLLAMA_URL env var in tags endpoint
- remove debug logging
- add comment about expected OLLAMA_URL setup

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_688d7c11d06c8322840c10604849fc18