### PR TITLE
Parameterize Postgres similarity table

### DIFF
--- a/src/connectors/postgresLoader.ts
+++ b/src/connectors/postgresLoader.ts
@@ -8,7 +8,9 @@ import { prisma } from '@/providers/prisma';
  * Loads documents from a Postgres query.
  */
 export class PostgresLoader extends Connector {
-  constructor(private query = 'SELECT 1') { super() }
+  constructor(private query = 'SELECT 1', private table = 'Embeddings') {
+    super()
+  }
 
   async ingest(): Promise<any[]> {
     return sql.unsafe(this.query)
@@ -29,7 +31,7 @@ export class PostgresLoader extends Connector {
 
   async similar(question: string, k: number): Promise<any[]> {
     const [e] = await embedChunks([question])
-    return sql`SELECT * FROM "FhirResource" ORDER BY embedding <-> ${e} LIMIT ${k}`
+    return sql`SELECT * FROM ${sql(this.table)} ORDER BY embedding <-> ${e} LIMIT ${k}`
   }
 
   async connected(): Promise<boolean> {

--- a/tests/postgresLoader.test.ts
+++ b/tests/postgresLoader.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { sqlMock } = vi.hoisted(() => {
+  const sqlMock = vi.fn((first: any, ...rest: any[]) => {
+    if (Array.isArray(first)) {
+      const strings = first as TemplateStringsArray
+      const values = rest
+      let text = strings[0]
+      let paramIndex = 1
+      for (let i = 0; i < values.length; i++) {
+        const v = values[i]
+        if (typeof v === 'string') {
+          text += v
+        } else {
+          text += `$${paramIndex++}`
+        }
+        text += strings[i + 1]
+      }
+      return Promise.resolve([{ text }])
+    }
+    return first
+  })
+  sqlMock.unsafe = vi.fn()
+  return { sqlMock }
+})
+
+vi.mock('../src/providers/db', () => ({ sql: sqlMock }))
+
+vi.mock('../src/lib/embedChunks', () => ({
+  embedChunks: vi.fn(async () => [[0.1, 0.2]])
+}))
+
+import { PostgresLoader } from '../src/connectors/postgresLoader'
+
+describe('PostgresLoader', () => {
+  it('queries the configured table for similarity', async () => {
+    const loader = new PostgresLoader('SELECT 1', 'MyTable')
+    const res = await loader.similar('hello', 2)
+    expect(res).toEqual([
+      { text: 'SELECT * FROM MyTable ORDER BY embedding <-> $1 LIMIT $2' }
+    ])
+    expect(sqlMock).toHaveBeenCalledTimes(2)
+    expect(sqlMock.mock.calls[0][0]).toBe('MyTable')
+  })
+})


### PR DESCRIPTION
## Summary
- allow PostgresLoader to target configurable embeddings table for similarity search
- add unit test verifying table name is used in similarity query

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d7c1298388322a468759ec1d9989b