### PR TITLE
chore: use pnpm in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test -- --coverage
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm run test -- --coverage
       - run: docker build .


### PR DESCRIPTION
## Summary
- fix ci workflow to use pnpm for installs and scripts

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run test -- --coverage`
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688e154115308322bfa01c7f9a875364