### PR TITLE
fix: remove redundant pnpm version from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- remove redundant pnpm version from CI workflow to avoid pnpm/action-setup conflict

## Testing
- `pnpm run lint`
- `pnpm run test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_b_688e1d9fcf6c83228ca2a3d229c5e6e8