### PR TITLE
Fix Docker build and handle missing DB config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM node:20-slim AS builder
 
 WORKDIR /app
 
+# Copy dependency manifests and Prisma schema early so that pnpm install
+# can run any postinstall scripts that rely on it.
 COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma
 
 RUN corepack enable && pnpm install --frozen-lockfile && mkdir -p /app/logs /app/cache
 

--- a/src/connectors/postgresLoader.ts
+++ b/src/connectors/postgresLoader.ts
@@ -1,23 +1,24 @@
-import { getDb } from '@/providers/db';
-import type { Sql } from 'postgres';
-import { uuid } from '@/lib/utils';
-import { Connector, Document } from './base';
-import { embedChunks } from '@/lib/embedChunks';
-import { prisma } from '@/providers/prisma';
+import { getDb } from '@/providers/db'
+import type { Sql } from 'postgres'
+import { uuid } from '@/lib/utils'
+import { Connector, Document } from './base'
+import { embedChunks } from '@/lib/embedChunks'
+import { prisma } from '@/providers/prisma'
 
 /**
  * Loads documents from a Postgres query.
  */
 export class PostgresLoader extends Connector {
-  private sql: Sql
-
   constructor(
     private query = 'SELECT 1',
     private table = 'Embeddings',
-    database = 'default'
+    private database = 'default'
   ) {
     super()
-    this.sql = getDb(database)
+  }
+
+  private get sql(): Sql {
+    return getDb(this.database)
   }
 
   async ingest(): Promise<any[]> {
@@ -39,7 +40,8 @@ export class PostgresLoader extends Connector {
 
   async similar(question: string, k: number): Promise<any[]> {
     const [e] = await embedChunks([question])
-    return this.sql`SELECT * FROM ${this.sql(this.table)} ORDER BY embedding <-> ${e} LIMIT ${k}`
+    const db = this.sql
+    return db`SELECT * FROM ${db(this.table)} ORDER BY embedding <-> ${e} LIMIT ${k}`
   }
 
   async connected(): Promise<boolean> {

--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -4,21 +4,28 @@ import { FhirLoader } from './fhirLoader'
 import { prisma } from '@/providers/prisma'
 import { connectorNames } from './names'
 
-/** Registry of available connectors */
-export const connectorRegistry: Record<(typeof connectorNames)[number], Connector> = {
-  postgres: new PostgresLoader(),
-  fhir: new FhirLoader()
+/** Registry of available connector factories */
+export const connectorRegistry: Record<(typeof connectorNames)[number], () => Connector> = {
+  postgres: () => new PostgresLoader(),
+  fhir: () => new FhirLoader(),
 }
 
 /**
  * Return connectors that have saved credentials.
+ *
+ * When the default database is not configured we simply return an empty
+ * registry so that builds can proceed without requiring a running database.
  */
 export async function getActiveConnectors(): Promise<Record<string, Connector>> {
+  if (!process.env.DATABASE_URL) {
+    return {}
+  }
+
   const secrets = await prisma.secret.findMany()
   const active: Record<string, Connector> = {}
-  for (const [name, connector] of Object.entries(connectorRegistry)) {
+  for (const [name, factory] of Object.entries(connectorRegistry)) {
     if (secrets.some((s) => s.source === name)) {
-      active[name] = connector
+      active[name] = factory()
     }
   }
   return active


### PR DESCRIPTION
## Summary
- copy Prisma schema before pnpm install so postinstall runs during Docker build
- lazily create connectors and skip DB access when `DATABASE_URL` is absent to avoid build-time errors
- postpone Postgres connection acquisition until runtime

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_6890de25510c8322bb8c000b411c4091