### PR TITLE
fix: fallback uuid generation for unsupported environments

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,14 @@
-import crypto from "crypto"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { v4 as uuidv4 } from "uuid"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const uuid = () => crypto.randomUUID()
+export const uuid = () => {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+  return uuidv4()
+}


### PR DESCRIPTION
## Summary
- avoid importing Node's `crypto` in `uuid` helper
- fallback to `uuid` library when `crypto.randomUUID` is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896935fd67883229e8a5a9e94a5fb35