### PR TITLE
feat: add plugin runtime for connectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1",
+    "zod": "^3.24.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
-        specifier: ^3.24.1
+        specifier: ^3.24.2
         version: 3.24.2
       zustand:
         specifier: ^5.0.3

--- a/src/app/api/connectors/route.ts
+++ b/src/app/api/connectors/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { loadPlugins, listConnectors } from "@/plugins/registry";
+
+let loaded = false;
+
+async function ensureLoaded() {
+  if (!loaded) {
+    await loadPlugins();
+    loaded = true;
+  }
+}
+
+export async function GET() {
+  await ensureLoaded();
+  const connectors = listConnectors();
+  return NextResponse.json({ connectors });
+}

--- a/src/db/registry.ts
+++ b/src/db/registry.ts
@@ -1,0 +1,16 @@
+import { getDb } from "@/providers/db";
+
+export interface DbAdapter {
+  query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<T[]>;
+  upsertEmbedding?(opts: { table: string; id: string; vector: number[]; payload?: Record<string, any> }): Promise<void>;
+  similar?(opts: { table: string; vector: number[]; topK?: number }): Promise<Array<{ id: string | number; score: number }>>;
+}
+
+export function getAdapter(name = "default"): DbAdapter {
+  const db = getDb(name);
+  return {
+    query<T = unknown>(sql: string, params: readonly unknown[] = []) {
+      return db.unsafe<T[]>(sql, params);
+    },
+  };
+}

--- a/src/hooks/useConnectors.ts
+++ b/src/hooks/useConnectors.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export function useConnectors() {
+  const [data, setData] = useState<{ pluginId: string; spec: any }[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch("/api/connectors");
+        const j = await r.json();
+        setData(j.connectors);
+      } catch (e: any) {
+        setError(e?.message ?? "Failed to load connectors");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/plugins/custom-http/manifest.ts
+++ b/src/plugins/custom-http/manifest.ts
@@ -1,0 +1,70 @@
+import { definePlugin } from "../define";
+import type { ConnectorFactory } from "../types";
+
+const create: ConnectorFactory = (config) => {
+  const baseUrl = config.baseUrl as string;
+  const apiKey = config.apiKey as string | undefined;
+
+  async function call<T = any>(path: string, body: any) {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { "Authorization": `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    async testConnection() {
+      try {
+        await call("/health", {});
+        return { ok: true as const };
+      } catch (e: any) {
+        return { ok: false as const, error: e?.message ?? "Unknown error" };
+      }
+    },
+
+    async query<T = unknown>({ path = "/query", body, sql, params }) {
+      // Support either generic /query { sql, params } or a custom body
+      const payload = body ?? (sql ? { sql, params } : {});
+      const out = await call<{ rows: T[] }>(path, payload);
+      return out.rows ?? [];
+    },
+
+    async ingest({ source, options }) {
+      const out = await call<{ count: number }>("/ingest", { source, options });
+      return { count: out.count ?? 0 };
+    },
+  };
+};
+
+const manifest = definePlugin({
+  id: "plugin-custom-http",
+  displayName: "Custom HTTP",
+  version: "0.1.0",
+  connectors: [
+    {
+      spec: {
+        id: "custom-http",
+        displayName: "Custom HTTP",
+        version: "0.1.0",
+        capabilities: ["http", "ingest"],
+        configSchema: [
+          { key: "baseUrl", label: "Base URL", type: "string", required: true, description: "e.g. https://my-data-api" },
+          { key: "apiKey", label: "API Key", type: "password", required: false, secret: true },
+        ],
+      },
+      create,
+    },
+  ],
+  tools: [],
+});
+
+export default manifest;

--- a/src/plugins/define.ts
+++ b/src/plugins/define.ts
@@ -1,0 +1,8 @@
+import type { PluginManifest } from "./types";
+import { PluginManifestZ } from "./types";
+
+export function definePlugin(manifest: PluginManifest): PluginManifest {
+  // runtime validation guard
+  const parsed = PluginManifestZ.parse(manifest);
+  return parsed;
+}

--- a/src/plugins/postgres-basic/manifest.ts
+++ b/src/plugins/postgres-basic/manifest.ts
@@ -1,0 +1,66 @@
+import { definePlugin } from "../define";
+import type { ConnectorFactory } from "../types";
+import { ConnectorSpecZ, CapabilityZ } from "../types";
+import { getAdapter } from "@/db/registry";
+
+const create: ConnectorFactory = (config: Record<string, any>) => {
+  // choose adapter by name; falls back to 'default' (A1 bootstrap)
+  const name = (config.databaseName as string) || "default";
+  const db = getAdapter(name);
+
+  return {
+    async testConnection() {
+      try {
+        await db.query("SELECT 1 as one");
+        return { ok: true as const };
+      } catch (e: any) {
+        return { ok: false as const, error: e?.message ?? "Unknown error" };
+      }
+    },
+
+    async query<T = unknown>({ sql, params = [] }) {
+      if (!sql) throw new Error("sql is required for Postgres connector");
+      const rows = await db.query<T>(sql, params);
+      return rows;
+    },
+
+    async upsertEmbedding({ table, id, vector, payload }) {
+      if (!db.upsertEmbedding) throw new Error("Vector not supported by this adapter");
+      await db.upsertEmbedding({ table, id, vector, payload });
+    },
+
+    async similar({ table, vector, topK }) {
+      if (!db.similar) throw new Error("Vector search not supported by this adapter");
+      return db.similar({ table, vector, topK });
+    },
+  };
+};
+
+const manifest = definePlugin({
+  id: "plugin-postgres-basic",
+  displayName: "Postgres (Basic)",
+  version: "0.1.0",
+  connectors: [
+    {
+      spec: {
+        id: "postgres-basic",
+        displayName: "Postgres",
+        version: "0.1.0",
+        capabilities: ["sql", "vector", "json", "fulltext"],
+        configSchema: [
+          {
+            key: "databaseName",
+            label: "Adapter Name",
+            type: "string",
+            required: false,
+            description: "Adapter to use (default = 'default'). Set via DATABASE_URL or DATABASE_URL_<NAME>.",
+          },
+        ],
+      },
+      create,
+    },
+  ],
+  tools: [],
+});
+
+export default manifest;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,0 +1,63 @@
+import type { PluginManifest, ConnectorSpec, ToolSpec, ConnectorFactory, ToolFactory } from "./types";
+import { definePlugin } from "./define";
+
+type LoadedConnector = { pluginId: string; spec: ConnectorSpec; create: ConnectorFactory };
+type LoadedTool = { pluginId: string; spec: ToolSpec; create: ToolFactory };
+
+const plugins: PluginManifest[] = [];
+const connectors: Map<string, LoadedConnector> = new Map();
+const tools: Map<string, LoadedTool> = new Map();
+
+export function listPlugins() {
+  return plugins.map(p => ({ id: p.id, displayName: p.displayName, version: p.version }));
+}
+
+export function listConnectors() {
+  return Array.from(connectors.values()).map(c => ({ pluginId: c.pluginId, spec: c.spec }));
+}
+
+export function listTools() {
+  return Array.from(tools.values()).map(t => ({ pluginId: t.pluginId, spec: t.spec }));
+}
+
+export function getConnector(id: string): LoadedConnector {
+  const c = connectors.get(id);
+  if (!c) throw new Error(`Connector '${id}' not found`);
+  return c;
+}
+
+export function getTool(id: string): LoadedTool {
+  const t = tools.get(id);
+  if (!t) throw new Error(`Tool '${id}' not found`);
+  return t;
+}
+
+/**
+ * Discover manifests at build/runtime. We explicitly enumerate to keep it stable
+ * for bundlers; you can add more entries below as you add plugins.
+ */
+export async function loadPlugins() {
+  // IMPORTANT: add any new plugin manifests here
+  const manifests: PluginManifest[] = [];
+
+  // Postgres basic plugin
+  const pg = await import("./src__plugins__postgres-basic__manifest");
+  manifests.push(definePlugin(pg.default));
+
+  // Custom HTTP plugin
+  const http = await import("./src__plugins__custom-http__manifest");
+  manifests.push(definePlugin(http.default));
+
+  // Register
+  for (const m of manifests) {
+    plugins.push(m);
+    for (const c of m.connectors) {
+      if (connectors.has(c.spec.id)) throw new Error(`Duplicate connector id: ${c.spec.id}`);
+      connectors.set(c.spec.id, { pluginId: m.id, spec: c.spec, create: c.create as any });
+    }
+    for (const t of m.tools) {
+      if (tools.has(t.spec.id)) throw new Error(`Duplicate tool id: ${t.spec.id}`);
+      tools.set(t.spec.id, { pluginId: m.id, spec: t.spec, create: t.create as any });
+    }
+  }
+}

--- a/src/plugins/src__plugins__custom-http__manifest.ts
+++ b/src/plugins/src__plugins__custom-http__manifest.ts
@@ -1,0 +1,1 @@
+export { default } from "./custom-http/manifest";

--- a/src/plugins/src__plugins__postgres-basic__manifest.ts
+++ b/src/plugins/src__plugins__postgres-basic__manifest.ts
@@ -1,0 +1,2 @@
+// bridge import so registry can "statically" import the manifest
+export { default } from "./postgres-basic/manifest";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+export const CapabilityZ = z.enum([
+  "sql",
+  "vector",
+  "json",
+  "fulltext",
+  "files",
+  "ingest",
+  "http",
+  "stream",
+]);
+
+export type Capability = z.infer<typeof CapabilityZ>;
+
+export const ConnectorConfigFieldZ = z.object({
+  key: z.string(),             // e.g. "DATABASE_URL" or "apiKey"
+  label: z.string(),           // e.g. "Database URL"
+  type: z.enum(["string", "number", "boolean", "password", "json"]),
+  required: z.boolean().default(true),
+  secret: z.boolean().default(false),
+  description: z.string().optional(),
+  defaultValue: z.any().optional(),
+});
+
+export type ConnectorConfigField = z.infer<typeof ConnectorConfigFieldZ>;
+
+export const ConnectorSpecZ = z.object({
+  id: z.string().min(1),           // "postgres-basic"
+  displayName: z.string().min(1),  // "Postgres (Basic)"
+  version: z.string().min(1),      // "0.1.0"
+  capabilities: z.array(CapabilityZ).default([]),
+  configSchema: z.array(ConnectorConfigFieldZ).default([]),
+});
+
+export type ConnectorSpec = z.infer<typeof ConnectorSpecZ>;
+
+export type QueryParams = readonly unknown[];
+
+export interface ConnectorInstance {
+  /** Optionally establish a connection or validate config. */
+  testConnection(): Promise<{ ok: true } | { ok: false; error: string }>;
+
+  /** Execute a query; semantics depend on capability "sql" or "http". */
+  query<T = unknown>(input: { sql?: string; params?: QueryParams; path?: string; body?: any }): Promise<T[]>;
+
+  /** Optional bulk ingestion hook (files/FHIR/etc.) */
+  ingest?(input: { source: string; options?: Record<string, any> }): Promise<{ count: number }>;
+
+  /** Optional vector operations */
+  upsertEmbedding?(opts: { table: string; id: string; vector: number[]; payload?: Record<string, any> }): Promise<void>;
+  similar?(opts: { table: string; vector: number[]; topK?: number }): Promise<Array<{ id: string | number; score: number }>>;
+}
+
+export type ConnectorFactory = (config: Record<string, any>) => ConnectorInstance;
+
+export const ToolSpecZ = z.object({
+  id: z.string().min(1),            // "sql-explain"
+  displayName: z.string().min(1),   // "Explain SQL"
+  version: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export type ToolSpec = z.infer<typeof ToolSpecZ>;
+
+export interface ToolImpl {
+  run(input: Record<string, any>): Promise<any>;
+}
+
+export type ToolFactory = () => ToolImpl;
+
+export const PluginManifestZ = z.object({
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  version: z.string().min(1),
+  connectors: z.array(z.object({
+    spec: ConnectorSpecZ,
+    create: z.function().args(z.record(z.any())).returns(z.any()),
+  })).default([]),
+  tools: z.array(z.object({
+    spec: ToolSpecZ,
+    create: z.function().args().returns(z.any()),
+  })).default([]),
+});
+
+export type PluginManifest = z.infer<typeof PluginManifestZ>;

--- a/tests/plugins/manifest-validate.test.ts
+++ b/tests/plugins/manifest-validate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { loadPlugins, listPlugins, listConnectors, getConnector } from "@/plugins/registry";
+
+vi.mock("@/db/registry", () => ({
+  getAdapter: () => ({
+    query: async (_sql: string) => [{ one: 1 }],
+  }),
+}));
+
+describe("Plugin runtime", () => {
+  beforeAll(async () => {
+    await loadPlugins();
+  });
+
+  it("loads plugins and connectors", () => {
+    const ps = listPlugins();
+    expect(ps.length).toBeGreaterThan(0);
+
+    const cs = listConnectors();
+    expect(cs.map(c => c.spec.id)).toContain("postgres-basic");
+    expect(cs.map(c => c.spec.id)).toContain("custom-http");
+  });
+
+  it("can create and use postgres-basic connector", async () => {
+    const { create } = getConnector("postgres-basic");
+    const conn = create({ databaseName: "default" });
+    const ok = await conn.testConnection();
+    expect(ok.ok).toBe(true);
+
+    const rows = await conn.query<{ one: number }>({ sql: "SELECT 1 as one" });
+    expect(rows[0].one).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add typed plugin manifest system and registry for connectors and tools
- include example postgres and custom HTTP connector plugins
- expose `/api/connectors` route and React hook to fetch discovered connectors

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm dev` & `curl -s localhost:3000/api/connectors | jq .`

## PR Checklist
- [x] Added src/plugins/types.ts, src/plugins/define.ts, src/plugins/registry.ts
- [x] Added example plugins: src/plugins/postgres-basic/manifest.ts, src/plugins/custom-http/manifest.ts
- [x] Added stable bridging imports for manifests in src/plugins/src__plugins__*__manifest.ts
- [x] API route GET /api/connectors returns discovered connectors
- [x] Unit tests for plugin discovery and postgres connector query
- [x] App boots and existing features remain unchanged

------
https://chatgpt.com/codex/tasks/task_b_68994e4733788322b1fed6987ebb1bea