### PR TITLE
feat: allow builds without database

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,8 +6,8 @@ import { z } from "zod";
  */
 const ServerEnvSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  // Primary DB for the app
-  DATABASE_URL: z.string().url().describe("Primary database URL (e.g., Postgres)"),
+  // Primary DB for the app (optional for builds without a DB)
+  DATABASE_URL: z.string().url().optional().describe("Primary database URL (e.g., Postgres)"),
   // Optional extra DBs (A1 auto-loaded via DATABASE_URL_<NAME>), so no need to list here.
   // LLM keys (make optional if you support multiple providers)
   OPENAI_API_KEY: z.string().min(1).optional(),

--- a/tests/config/env.test.ts
+++ b/tests/config/env.test.ts
@@ -2,13 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 
 // IMPORTANT: import lazily to allow env injection
 describe("env", () => {
-  it("fails when DATABASE_URL missing", async () => {
+  it("loads even when DATABASE_URL missing", async () => {
     const OLD = process.env.DATABASE_URL;
     delete process.env.DATABASE_URL;
-    await expect(async () => {
-      vi.resetModules();
-      await import("@/config/env");
-    }).rejects.toThrow(/DATABASE_URL/i);
+    vi.resetModules();
+    const { env } = await import("@/config/env");
+    expect(env.server.DATABASE_URL).toBeUndefined();
     if (OLD) process.env.DATABASE_URL = OLD;
   });
 

--- a/tests/db/postgres-adapter.test.ts
+++ b/tests/db/postgres-adapter.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createPostgresAdapter } from '@/db/adapters/postgres';
 
-let db: ReturnType<typeof createPostgresAdapter>;
+const url = process.env.DATABASE_URL;
 
-describe('PostgresAdapter', () => {
+(url ? describe : describe.skip)('PostgresAdapter', () => {
+  let db: ReturnType<typeof createPostgresAdapter>;
+
   beforeAll(() => {
-    const url = process.env.DATABASE_URL;
-    if (!url) throw new Error('DATABASE_URL not set for tests');
-    db = createPostgresAdapter(url);
+    db = createPostgresAdapter(url!);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- make `DATABASE_URL` optional so builds can run without a database
- adjust env tests to expect optional DB
- skip Postgres adapter tests when no DB URL

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_68998ed465f88322854fe509e76d5e43