### PR TITLE
feat: add multi-tenant org model with RLS

### DIFF
--- a/prisma/migrations/20250101000000_a4_multitenant_org_rls/migration.sql
+++ b/prisma/migrations/20250101000000_a4_multitenant_org_rls/migration.sql
@@ -1,0 +1,100 @@
+-- Core tables
+CREATE TABLE IF NOT EXISTS organizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS memberships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id text NOT NULL,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  role text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, organization_id)
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  hashed_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_used_at timestamptz,
+  disabled boolean NOT NULL DEFAULT false
+);
+
+-- Example tenant-owned table
+CREATE TABLE IF NOT EXISTS datasets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  meta jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_datasets_org ON datasets(organization_id);
+
+-- Existing table: FhirResource
+ALTER TABLE "FhirResource" ADD COLUMN IF NOT EXISTS organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_fhirresource_org ON "FhirResource"(organization_id);
+
+-- Enable RLS on tenant-owned tables
+ALTER TABLE datasets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "FhirResource" ENABLE ROW LEVEL SECURITY;
+
+-- Application-defined GUC function
+CREATE OR REPLACE FUNCTION app.get_current_org() RETURNS uuid
+LANGUAGE sql STABLE AS $$
+  SELECT nullif(current_setting('app.current_org_id', true), '')::uuid
+$$;
+
+-- Policies for datasets
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'datasets_rls_select'
+  ) THEN
+    CREATE POLICY datasets_rls_select ON datasets
+      FOR SELECT USING (organization_id = app.get_current_org());
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'datasets_rls_mod'
+  ) THEN
+    CREATE POLICY datasets_rls_mod ON datasets
+      FOR INSERT WITH CHECK (organization_id = app.get_current_org());
+    CREATE POLICY datasets_rls_update ON datasets
+      FOR UPDATE USING (organization_id = app.get_current_org()) WITH CHECK (organization_id = app.get_current_org());
+    CREATE POLICY datasets_rls_delete ON datasets
+      FOR DELETE USING (organization_id = app.get_current_org());
+  END IF;
+END$$;
+
+-- Policies for FhirResource
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'fhirresource_rls_select'
+  ) THEN
+    CREATE POLICY fhirresource_rls_select ON "FhirResource"
+      FOR SELECT USING (organization_id = app.get_current_org());
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE polname = 'fhirresource_rls_mod'
+  ) THEN
+    CREATE POLICY fhirresource_rls_mod ON "FhirResource"
+      FOR INSERT WITH CHECK (organization_id = app.get_current_org());
+    CREATE POLICY fhirresource_rls_update ON "FhirResource"
+      FOR UPDATE USING (organization_id = app.get_current_org()) WITH CHECK (organization_id = app.get_current_org());
+    CREATE POLICY fhirresource_rls_delete ON "FhirResource"
+      FOR DELETE USING (organization_id = app.get_current_org());
+  END IF;
+END$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,53 @@ generator client {
   previewFeatures = ["postgresqlExtensions"]
 }
 
+model Organization {
+  id        String       @id @default(uuid())
+  name      String
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  memberships Membership[]
+  apiKeys     ApiKey[]
+  datasets    Dataset[]
+  fhirResources FhirResource[]
+}
+
+model Membership {
+  id             String       @id @default(uuid())
+  userId         String
+  organizationId String
+  role           String
+  createdAt      DateTime     @default(now())
+
+  organization   Organization @relation(fields: [organizationId], references: [id])
+
+  @@unique([userId, organizationId])
+}
+
+model ApiKey {
+  id             String       @id @default(uuid())
+  organizationId String
+  name           String
+  hashedKey      String
+  createdAt      DateTime     @default(now())
+  lastUsedAt     DateTime?
+  disabled       Boolean      @default(false)
+
+  organization   Organization @relation(fields: [organizationId], references: [id])
+}
+
+model Dataset {
+  id             String       @id @default(uuid())
+  organizationId String
+  name           String
+  meta           Json?
+
+  organization   Organization @relation(fields: [organizationId], references: [id])
+
+  @@index([organizationId])
+}
+
 model FhirResource {
   id           String                @id @default(cuid())
   resourceType String
@@ -19,9 +66,13 @@ model FhirResource {
   rawJson      Json
   chunkText    String                @db.Text
   embedding    Unsupported("vector")
+  organizationId String
   createdAt    DateTime              @default(now())
 
+  organization   Organization @relation(fields: [organizationId], references: [id])
+
   @@index([patientId])
+  @@index([organizationId])
 }
 
 model Secret {

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireTenant } from '@/lib/handlers/withTenant';
+import { withTenant } from '@/db/withTenant';
+
+export const GET = requireTenant(async (_req: NextRequest, { orgId }) => {
+  return withTenant(orgId, async (db) => {
+    const rows = await db.query('SELECT id, name, meta FROM datasets ORDER BY name');
+    return NextResponse.json({ ok: true, rows });
+  });
+});
+
+export const POST = requireTenant(async (req: NextRequest, { orgId }) => {
+  const { name, meta } = await req.json();
+  return withTenant(orgId, async (db) => {
+    await db.query(
+      'INSERT INTO datasets (organization_id, name, meta) VALUES ($1, $2, $3)',
+      [orgId, name ?? 'Untitled', meta ?? null]
+    );
+    return NextResponse.json({ ok: true });
+  });
+});

--- a/src/app/api/orgs/route.ts
+++ b/src/app/api/orgs/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdapter } from '@/db/registry';
+
+export async function POST(req: NextRequest) {
+  const { name } = await req.json();
+  if (!name) return NextResponse.json({ ok: false, error: 'name required' }, { status: 400 });
+
+  const db = getAdapter('default');
+  const rows = await db.query<{ id: string }>(
+    'INSERT INTO organizations (name) VALUES ($1) RETURNING id',
+    [name]
+  );
+  return NextResponse.json({ ok: true, id: rows[0].id });
+}

--- a/src/components/org/OrgSwitcher.tsx
+++ b/src/components/org/OrgSwitcher.tsx
@@ -1,0 +1,29 @@
+"use client";
+import * as React from 'react';
+
+export function OrgSwitcher() {
+  const [orgId, setOrgId] = React.useState<string>(() =>
+    typeof window !== 'undefined' ? localStorage.getItem('orgId') ?? '' : ''
+  );
+
+  function apply(id: string) {
+    setOrgId(id);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('orgId', id);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        className="rounded-md border px-2 py-1 text-sm w-[320px]"
+        placeholder="Paste org UUID…"
+        value={orgId}
+        onChange={(e) => apply(e.target.value)}
+      />
+      <span className="text-xs text-gray-500">
+        Sent as <code>x-org-id</code> header
+      </span>
+    </div>
+  );
+}

--- a/src/connectors/fhirLoader.ts
+++ b/src/connectors/fhirLoader.ts
@@ -67,7 +67,8 @@ export class FhirLoader extends Connector {
               chunkText: c.text,
               embedding: embeds[i],
               patientId: undefined,
-              encounterId: undefined
+              encounterId: undefined,
+              organizationId: process.env.ORG_ID || ''
             }
           })
         } catch (err) {

--- a/src/db/withTenant.ts
+++ b/src/db/withTenant.ts
@@ -1,0 +1,20 @@
+import { getAdapter } from './registry';
+
+export async function withTenant<T>(orgId: string, fn: (db: ReturnType<typeof getAdapter>) => Promise<T>) {
+  const db = getAdapter('default');
+
+  if ((db as any).name === 'postgres') {
+    await db.query('BEGIN');
+    try {
+      await db.query("SELECT set_config('app.current_org_id', $1, true)", [orgId]);
+      const out = await fn(db);
+      await db.query('COMMIT');
+      return out;
+    } catch (e) {
+      await db.query('ROLLBACK');
+      throw e;
+    }
+  }
+
+  return fn(db);
+}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,9 @@
+export async function apiFetch(path: string, init: RequestInit = {}) {
+  const base = typeof window === 'undefined' ? process.env.NEXT_PUBLIC_BASE_URL ?? '' : '';
+  const orgId = typeof window !== 'undefined' ? localStorage.getItem('orgId') ?? '' : '';
+
+  const headers = new Headers(init.headers || {});
+  if (orgId) headers.set('x-org-id', orgId);
+
+  return fetch(base + path, { ...init, headers, cache: 'no-store' });
+}

--- a/src/lib/handlers/withTenant.ts
+++ b/src/lib/handlers/withTenant.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveTenantFromRequest } from '@/lib/tenant';
+
+export function requireTenant<T extends (req: NextRequest, ctx: { orgId: string }) => Promise<NextResponse>>(handler: T) {
+  return async (req: NextRequest) => {
+    const tx = resolveTenantFromRequest(req);
+    if (!tx?.orgId) {
+      return NextResponse.json({ ok: false, error: 'Missing tenant (x-org-id)' }, { status: 400 });
+    }
+    return handler(req, { orgId: tx.orgId });
+  };
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -1,0 +1,15 @@
+export type TenantContext = {
+  orgId: string;
+  orgSlug?: string;
+  userId?: string;
+  roles?: string[];
+};
+
+export function resolveTenantFromRequest(req: Request | { headers: Headers }): TenantContext | null {
+  const h = req instanceof Request ? req.headers : req.headers;
+  const orgId = h.get("x-org-id");
+  const orgSlug = h.get("x-org-slug");
+
+  if (orgId) return { orgId, orgSlug: orgSlug ?? undefined };
+  return null;
+}

--- a/tests/tenant/rls.test.ts
+++ b/tests/tenant/rls.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getAdapter } from '@/db/registry';
+
+async function withOrg(orgId: string, fn: (query: (sql: string, params?: any[]) => Promise<any[]>) => Promise<void>) {
+  const db = getAdapter('default');
+  await db.query('BEGIN');
+  try {
+    await db.query("SELECT set_config('app.current_org_id', $1, true)", [orgId]);
+    await fn((sql, params = []) => db.query(sql, params));
+    await db.query('COMMIT');
+  } catch (e) {
+    await db.query('ROLLBACK');
+    throw e;
+  }
+}
+
+const url = process.env.DATABASE_URL;
+
+(url ? describe : describe.skip)('RLS isolation', () => {
+  it('prevents cross-org reads', async () => {
+    const db = getAdapter('default');
+    const [o1] = await db.query<{ id: string }>('INSERT INTO organizations (name) VALUES ($1) RETURNING id', ['Org A']);
+    const [o2] = await db.query<{ id: string }>('INSERT INTO organizations (name) VALUES ($1) RETURNING id', ['Org B']);
+
+    await withOrg(o1.id, async (q) => {
+      await q('INSERT INTO datasets (organization_id, name) VALUES ($1, $2)', [o1.id, 'A-only']);
+    });
+    await withOrg(o2.id, async (q) => {
+      await q('INSERT INTO datasets (organization_id, name) VALUES ($1, $2)', [o2.id, 'B-only']);
+    });
+
+    await withOrg(o1.id, async (q) => {
+      const rows = await q('SELECT name FROM datasets ORDER BY name');
+      expect(rows.map((r: any) => r.name)).toEqual(['A-only']);
+    });
+
+    await withOrg(o2.id, async (q) => {
+      const rows = await q('SELECT name FROM datasets ORDER BY name');
+      expect(rows.map((r: any) => r.name)).toEqual(['B-only']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Organization, Membership, ApiKey, Dataset models and link FhirResource to organizations
- enforce row level security using session GUC and withTenant helper
- expose API routes and client helpers to operate within a selected organization

## Testing
- `pnpm prisma generate`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_689a42e54e088322899473120f8de9e2