### PR TITLE
Allow builds without Redis

### DIFF
--- a/src/app/api/jobs/ingest/route.ts
+++ b/src/app/api/jobs/ingest/route.ts
@@ -35,6 +35,10 @@ export async function POST(req: NextRequest) {
 
   const jobId = audit.id;
 
+  if (!queue) {
+    return NextResponse.json({ ok: false, error: "Queue not configured" }, { status: 500 });
+  }
+
   await queue.add(payload.type, payload, { jobId });
 
   return NextResponse.json({ ok: true, id: jobId });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -14,7 +14,8 @@ const ServerEnvSchema = z.object({
   ANTHROPIC_API_KEY: z.string().min(1).optional(),
   // Misc runtime knobs
   PORT: z.coerce.number().default(3000),
-  REDIS_URL: z.string().url().describe("Redis connection URL for BullMQ"),
+  // Queue backend; optional for builds that don't need background jobs
+  REDIS_URL: z.string().url().optional().describe("Redis connection URL for BullMQ"),
   QUEUE_CONCURRENCY: z.coerce.number().default(5),
   // Feature flags (as strings -> booleans later)
   ENABLE_CONNECTOR_HTTP: z.string().optional(), // "true"/"false"

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -3,25 +3,35 @@ import IORedis from "ioredis";
 import { env } from "@/config/env";
 import type { AnyJob } from "./jobs";
 
-const connection = new IORedis(env.server.REDIS_URL, {
-  maxRetriesPerRequest: null,
-  enableReadyCheck: false,
-});
-
 export const DATAI_QUEUE_NAME = "datai-jobs";
 
-export const queue = new Queue<AnyJob>(DATAI_QUEUE_NAME, {
-  connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 1500 },
-    removeOnComplete: true,
-    removeOnFail: false,
-  } as JobsOptions,
-});
+// Only create a Redis connection when configured. This allows the app to build
+// without Redis for tests or environments that don't need background jobs.
+let connection: IORedis | undefined;
+if (env.server.REDIS_URL) {
+  connection = new IORedis(env.server.REDIS_URL, {
+    maxRetriesPerRequest: null,
+    enableReadyCheck: false,
+  });
+}
 
-export const queueEvents = new QueueEvents(DATAI_QUEUE_NAME, { connection });
+export const queue = connection
+  ? new Queue<AnyJob>(DATAI_QUEUE_NAME, {
+      connection,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: { type: "exponential", delay: 1500 },
+        removeOnComplete: true,
+        removeOnFail: false,
+      } as JobsOptions,
+    })
+  : null;
+
+export const queueEvents = connection
+  ? new QueueEvents(DATAI_QUEUE_NAME, { connection })
+  : null;
 
 export async function assertQueueHealthy() {
+  if (!queue) throw new Error("Queue not configured (missing REDIS_URL)");
   await queue.waitUntilReady();
 }


### PR DESCRIPTION
## Summary
- make REDIS_URL optional so builds can run without Redis
- guard queue and worker initialization when REDIS_URL is unset
- return an error from ingest API when queue isn't configured

## Testing
- `pnpm lint`
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_689ab7e7cae483229481db7ca19557d5