### PR TITLE
feat: add FHIR ingest connector

### DIFF
--- a/docs/FHIR_CONNECTOR.md
+++ b/docs/FHIR_CONNECTOR.md
@@ -1,0 +1,13 @@
+# FHIR Connector
+
+The FHIR connector ingests resources from an HL7 FHIR server via bulk `$export` or RESTful search pagination.
+
+## Usage
+
+1. Configure the connector with the FHIR server `baseUrl` and authentication.
+2. POST to `/api/fhir/ingest` with parameters such as dataset ID, mode (`bulk` or `search`), resource types, and optional `since` watermark.
+3. The job streams resources, flattens them to text, deduplicates by SHA-1 hash, and stores document chunks.
+
+## PHI Considerations
+
+FHIR data often contains Protected Health Information (PHI). Ensure you have appropriate permissions and safeguards before ingesting any data. Uploaded resources are stored in raw form alongside derived text chunks; handle access accordingly.

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tesseract.js": "^6.0.1",
+    "undici": "^7.13.0",
     "uuid": "^10.0.0",
     "vaul": "^1.1.2",
     "zod": "^3.24.2",
@@ -114,7 +115,7 @@
   "devDependencies": {
     "@types/ioredis": "^5.0.0",
     "@types/lodash": "^4.17.15",
-    "@types/node": "^22.13.0",
+    "@types/node": "^22.13.4",
     "@types/pg": "^8.11.11",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       tesseract.js:
         specifier: ^6.0.1
         version: 6.0.1(encoding@0.1.13)
+      undici:
+        specifier: ^7.13.0
+        version: 7.13.0
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -286,7 +289,7 @@ importers:
         specifier: ^4.17.15
         version: 4.17.15
       '@types/node':
-        specifier: ^22.13.0
+        specifier: ^22.13.4
         version: 22.13.4
       '@types/pg':
         specifier: ^8.11.11
@@ -8452,6 +8455,10 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  undici@7.13.0:
+    resolution: {integrity: sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -18713,6 +18720,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.20.0: {}
+
+  undici@7.13.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/prisma/migrations/20250813_add_ingest_cursors/migration.sql
+++ b/prisma/migrations/20250813_add_ingest_cursors/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS ingest_cursors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  dataset_id uuid NOT NULL REFERENCES datasets(id) ON DELETE CASCADE,
+  source text NOT NULL,
+  mode text NOT NULL,
+  resource_types text[] NOT NULL,
+  since timestamptz,
+  resume_url text,
+  resume_next text,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(organization_id, dataset_id, source, mode)
+);
+
+ALTER TABLE ingest_cursors ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE polname='ingest_cursors_rls') THEN
+    CREATE POLICY ingest_cursors_rls ON ingest_cursors
+      USING (organization_id = app.get_current_org())
+      WITH CHECK (organization_id = app.get_current_org());
+  END IF;
+END$$;

--- a/src/app/api/fhir/ingest/route.ts
+++ b/src/app/api/fhir/ingest/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveTenantFromRequest } from "@/lib/tenant";
+import { queue } from "@/queue/queue";
+import { FhirIngestZ } from "@/queue/jobs";
+
+export async function POST(req: NextRequest) {
+  const tx = resolveTenantFromRequest(req);
+  if (!tx?.orgId) return NextResponse.json({ ok:false, error:"Missing tenant (x-org-id)" }, { status:400 });
+
+  const body = await req.json();
+  const parsed = FhirIngestZ.safeParse({ ...body, type: "fhir.ingest", orgId: tx.orgId });
+  if (!parsed.success) return NextResponse.json({ ok:false, error: parsed.error.message }, { status:400 });
+
+  const job = await queue.add("fhir.ingest", parsed.data);
+  return NextResponse.json({ ok:true, id: job.id });
+}

--- a/src/connectors/fhir/client.ts
+++ b/src/connectors/fhir/client.ts
@@ -1,0 +1,89 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { createGunzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+
+export type Auth =
+  | { kind: "bearer"; token: string }
+  | { kind: "basic"; username: string; password: string }
+  | { kind: "none" };
+
+export type FhirMode = "bulk" | "search";
+
+export function authHeaders(a: Auth): Record<string,string> {
+  if (a.kind === "bearer") return { Authorization: `Bearer ${a.token}` };
+  if (a.kind === "basic") return { Authorization: `Basic ${Buffer.from(`${a.username}:${a.password}`).toString("base64")}` };
+  return {};
+}
+
+export async function getJSON<T>(url: string, auth: Auth, extra?: Record<string,string>): Promise<T> {
+  const r = await fetch(url, { headers: { Accept: "application/fhir+json", ...authHeaders(auth), ...(extra||{}) } });
+  if (!r.ok) throw new Error(`GET ${url} ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
+export async function* ndjsonLines(res: Response): AsyncGenerator<string> {
+  // Supports plain ndjson or gzip (content-encoding or .gz)
+  let stream: any = res.body as any;
+  const enc = res.headers.get("content-encoding");
+  if (enc && enc.includes("gzip")) {
+    const gunzip = createGunzip();
+    await pipeline(Readable.from(stream), gunzip);
+    stream = gunzip;
+  }
+  let buf = "";
+  for await (const chunk of (stream as any)) {
+    buf += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+    let idx: number;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx+1);
+      if (line) yield line;
+    }
+  }
+  if (buf.trim()) yield buf.trim();
+}
+
+export async function startBulkExport(baseUrl: string, auth: Auth, scope: { level: "system"|"patient"|"group"; id?: string }, resourceTypes?: string[], since?: string) {
+  const params = new URLSearchParams();
+  if (resourceTypes?.length) params.set("_type", resourceTypes.join(","));
+  if (since) params.set("_since", since);
+  const url =
+    scope.level === "system" ? `${baseUrl}/$export?${params}` :
+    scope.level === "patient" ? `${baseUrl}/Patient/${scope.id}/$export?${params}` :
+    `${baseUrl}/Group/${scope.id}/$export?${params}`;
+
+  const r = await fetch(url, {
+    method: "GET",
+    headers: {
+      ...authHeaders(auth),
+      Accept: "application/fhir+json",
+      Prefer: "respond-async",
+    }
+  });
+  if (r.status !== 202) throw new Error(`$export expected 202, got ${r.status}`);
+  const poll = r.headers.get("content-location");
+  if (!poll) throw new Error("Missing Content-Location for $export");
+  return { pollUrl: poll };
+}
+
+export async function pollBulkReady(pollUrl: string, auth: Auth, { maxWaitMs = 5 * 60_000, intervalMs = 2_000 } = {}) {
+  const t0 = Date.now();
+  for (;;) {
+    const r = await fetch(pollUrl, { headers: authHeaders(auth) });
+    if (r.status === 200) return (await r.json()) as any; // should contain output urls
+    if (r.status !== 202) throw new Error(`$export poll ${r.status}`);
+    const ra = parseInt(r.headers.get("retry-after") || "0", 10);
+    const wait = Number.isFinite(ra) && ra > 0 ? ra * 1000 : intervalMs;
+    await delay(wait);
+    if (Date.now() - t0 > maxWaitMs) throw new Error("Bulk export timed out");
+  }
+}
+
+export async function* downloadBulkFiles(output: Array<{ type: string; url: string }>, auth: Auth) {
+  for (const f of output) {
+    const r = await fetch(f.url, { headers: authHeaders(auth) });
+    if (!r.ok) throw new Error(`download ${f.url} ${r.status}`);
+    yield { type: f.type, response: r };
+  }
+}

--- a/src/connectors/fhir/flatten.ts
+++ b/src/connectors/fhir/flatten.ts
@@ -1,0 +1,74 @@
+// Minimal, readable projection from a FHIR Resource to text.
+// We avoid LLMs here; just pick salient fields per type with fallbacks.
+
+type AnyRes = { resourceType: string; id?: string; [k:string]: any };
+
+function val(x: any): string {
+  if (x == null) return "";
+  if (typeof x === "string" || typeof x === "number" || typeof x === "boolean") return String(x);
+  if (Array.isArray(x)) return x.map(val).filter(Boolean).join("; ");
+  if (x.text) return val(x.text);
+  if (x.coding && Array.isArray(x.coding)) return x.coding.map((c:any)=>c.display||c.code).filter(Boolean).join(", ");
+  return "";
+}
+
+export function flattenResource(r: AnyRes): { title: string; text: string } {
+  const t = r.resourceType;
+  const id = r.id ?? "";
+  const header = `${t}/${id}`;
+
+  const chunks: string[] = [];
+  const push = (k: string, v: any) => { const s = val(v); if (s) chunks.push(`${k}: ${s}`); };
+
+  switch (t) {
+    case "Patient":
+      push("name", r.name?.map((n:any)=>[n.given?.join(" "), n.family].filter(Boolean).join(" ")));
+      push("gender", r.gender);
+      push("birthDate", r.birthDate);
+      push("address", r.address?.[0]?.text);
+      break;
+
+    case "Condition":
+      push("code", r.code);
+      push("clinicalStatus", r.clinicalStatus);
+      push("onset", r.onsetDateTime || r.onsetPeriod);
+      push("note", r.note?.map((n:any)=>n.text));
+      push("subject", r.subject?.display || r.subject?.reference);
+      break;
+
+    case "Observation":
+      push("code", r.code);
+      push("value", r.valueQuantity || r.valueString || r.valueCodeableConcept);
+      push("interpretation", r.interpretation);
+      push("effective", r.effectiveDateTime || r.effectivePeriod);
+      push("subject", r.subject?.display || r.subject?.reference);
+      break;
+
+    case "DocumentReference":
+      push("type", r.type);
+      push("category", r.category);
+      push("date", r.date);
+      push("description", r.description);
+      push("content", r.content?.map((c:any)=>c.attachment?.title || c.attachment?.url || c.attachment?.contentType));
+      break;
+
+    case "Encounter":
+      push("class", r.class);
+      push("type", r.type);
+      push("period", r.period);
+      push("reason", r.reasonCode);
+      push("subject", r.subject?.display || r.subject?.reference);
+      break;
+
+    default:
+      // Generic fallback: use meta + text.div if present
+      push("meta", r.meta);
+      if (r.text?.div) {
+        const stripped = String(r.text.div).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+        push("summary", stripped);
+      }
+  }
+
+  const text = [header, ...chunks].join("\n");
+  return { title: header, text };
+}

--- a/src/plugins/fhir/manifest.ts
+++ b/src/plugins/fhir/manifest.ts
@@ -1,0 +1,61 @@
+import { definePlugin } from "../define";
+import type { ConnectorFactory } from "../types";
+import { z } from "zod";
+import { getJSON } from "@/connectors/fhir/client";
+
+const ConfigZ = z.object({
+  baseUrl: z.string().url(),
+  auth: z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("bearer"), token: z.string() }),
+    z.object({ kind: z.literal("basic"), username: z.string(), password: z.string() }),
+    z.object({ kind: z.literal("none") }),
+  ]).default({ kind: "none" }),
+});
+
+const create: ConnectorFactory = (configRaw) => {
+  const cfg = ConfigZ.parse(configRaw);
+
+  return {
+    async testConnection() {
+      try {
+        await getJSON(`${cfg.baseUrl}/metadata`, cfg.auth);
+        return { ok: true as const };
+      } catch (e: any) {
+        return { ok: false as const, error: e?.message ?? "FHIR /metadata failed" };
+      }
+    },
+
+    // Optional: direct query in future; for now we focus on ingest()
+    async ingest({ source, options }: { source: string; options?: any }) {
+      // This connector is used via the fhir.ingest job; actual logic lives in the worker.
+      return { count: 0 };
+    },
+  };
+};
+
+const manifest = definePlugin({
+  id: "plugin-fhir",
+  displayName: "FHIR (HL7)",
+  version: "0.1.0",
+  connectors: [
+    {
+      spec: {
+        id: "fhir",
+        displayName: "FHIR Server",
+        version: "0.1.0",
+        capabilities: ["json", "ingest"],
+        configSchema: [
+          { key: "baseUrl", label: "Base URL", type: "string", required: true },
+          { key: "auth.kind", label: "Auth Type", type: "select", required: true, choices: ["bearer","basic","none"], defaultValue: "none" },
+          { key: "auth.token", label: "Bearer Token", type: "password", required: false, secret: true },
+          { key: "auth.username", label: "Username", type: "string", required: false },
+          { key: "auth.password", label: "Password", type: "password", required: false, secret: true },
+        ],
+      },
+      create,
+    },
+  ],
+  tools: [],
+});
+
+export default manifest;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -81,6 +81,9 @@ export async function loadPlugins() {
       const az = await import("./src__plugins__azure-blob__manifest");
       manifests.push(definePlugin(az.default));
 
+      const fhir = await import("./src__plugins__fhir__manifest");
+      manifests.push(definePlugin(fhir.default));
+
       // Register
       for (const m of manifests) {
         plugins.push(m);

--- a/src/plugins/src__plugins__fhir__manifest.ts
+++ b/src/plugins/src__plugins__fhir__manifest.ts
@@ -1,0 +1,1 @@
+export { default } from "./fhir/manifest";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -16,11 +16,12 @@ export type Capability = z.infer<typeof CapabilityZ>;
 export const ConnectorConfigFieldZ = z.object({
   key: z.string(),             // e.g. "DATABASE_URL" or "apiKey"
   label: z.string(),           // e.g. "Database URL"
-  type: z.enum(["string", "number", "boolean", "password", "json"]),
+  type: z.enum(["string", "number", "boolean", "password", "json", "select"]),
   required: z.boolean().default(true),
   secret: z.boolean().default(false),
   description: z.string().optional(),
   defaultValue: z.any().optional(),
+  choices: z.array(z.string()).optional(),
 });
 
 export type ConnectorConfigField = z.infer<typeof ConnectorConfigFieldZ>;

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -1,7 +1,7 @@
 import { Worker, Job } from "bullmq";
 import IORedis from "ioredis";
 import { env } from "@/config/env";
-import { AnyJob, ConnectorIngestZ, DatasetEmbedZ, FilesIngestZ } from "./jobs";
+import { AnyJob, ConnectorIngestZ, DatasetEmbedZ, FilesIngestZ, FhirIngestZ } from "./jobs";
 import { DATAI_QUEUE_NAME } from "./queue";
 import { withTenant } from "@/db/withTenant";
 import { getAdapter } from "@/db/registry";
@@ -13,6 +13,11 @@ import { startOtelOnce } from "@/observability/otel";
 import { childLogger } from "@/observability/logger";
 import { getTraceIds } from "@/observability/correlation";
 import { auditLlmCall } from "@/observability/audit";
+import { flattenResource } from "@/connectors/fhir/flatten";
+import { chunkText } from "@/ingest/chunker";
+import { saveDocumentWithChunksDedup } from "@/ingest/saveDocumentWithChunksDedup";
+import { startBulkExport, pollBulkReady, downloadBulkFiles, ndjsonLines, getJSON } from "@/connectors/fhir/client";
+import crypto from "node:crypto";
 
 await startOtelOnce();
 
@@ -41,6 +46,113 @@ async function updateAudit(job: Job, patch: Partial<{ status: string; progress: 
   if (patch.error) { fields.push(`error = $${fields.length + 1}`); vals.push(patch.error); }
   if (!fields.length) return;
   await db.query(`UPDATE jobs SET ${fields.join(", ")}, updated_at = now() WHERE id = $${fields.length + 1}`, [...vals, id]);
+}
+
+async function processFhirIngest(job: Job<any>) {
+  const payload = FhirIngestZ.parse(job.data);
+  const { orgId, datasetId, config, mode, scope, resourceTypes, since, pageSize } = payload;
+
+  return withTenant(orgId, async (db) => {
+    const source = `fhir:${config.baseUrl}`;
+    const [cur] = await db.query<any>(`SELECT * FROM ingest_cursors WHERE dataset_id=$1 AND source=$2 AND mode=$3`, [datasetId, source, mode]);
+
+    let total = 0;
+
+    if (mode === "bulk") {
+      let pollUrl = cur?.resume_url;
+      if (!pollUrl) {
+        const { pollUrl: p } = await startBulkExport(config.baseUrl, config.auth, scope, resourceTypes, since);
+        pollUrl = p;
+        await db.query(
+          `INSERT INTO ingest_cursors (organization_id, dataset_id, source, mode, resource_types, since, resume_url, resume_next)
+           VALUES (app.get_current_org(), $1, $2, $3, $4, $5, $6, NULL)
+           ON CONFLICT (organization_id, dataset_id, source, mode) DO UPDATE SET resume_url = EXCLUDED.resume_url, updated_at = now()`,
+          [datasetId, source, mode, resourceTypes, since ?? null, pollUrl]
+        );
+      }
+
+      const ready = await pollBulkReady(pollUrl, config.auth);
+      let processed = 0;
+      for await (const file of downloadBulkFiles(ready.output || [], config.auth)) {
+        for await (const line of ndjsonLines(file.response)) {
+          const obj = JSON.parse(line);
+          const res = obj.resourceType ? obj : (obj.resource ?? obj);
+          const { title, text } = flattenResource(res);
+          const json = JSON.stringify(res);
+          const sha1 = crypto.createHash("sha1").update(json).digest("hex");
+          const chunks = chunkText(text, { maxTokens: 3500, overlap: 150 });
+
+          await saveDocumentWithChunksDedup({
+            orgId, datasetId,
+            source: `${source}/${res.resourceType}/${res.id ?? crypto.randomUUID()}`,
+            title, mimeType: "application/fhir+json",
+            contentSha1: sha1, rawBytesLen: Buffer.byteLength(json),
+            sourceEtag: null, sourceMtime: res.meta?.lastUpdated ? new Date(res.meta.lastUpdated) : null,
+            chunks
+          });
+
+          processed++;
+          total++;
+          if (processed % 500 === 0) await job.updateProgress(Math.min(99, processed % 10000));
+        }
+      }
+
+      const newSince = new Date().toISOString();
+      await db.query(
+        `UPDATE ingest_cursors SET resume_url=NULL, since=$1, updated_at=now() WHERE organization_id=app.get_current_org() AND dataset_id=$2 AND source=$3 AND mode=$4`,
+        [newSince, datasetId, source, mode]
+      );
+    } else {
+      for (const rt of resourceTypes) {
+        let nextUrl = cur?.resume_next || `${config.baseUrl}/${rt}?_count=${pageSize}` + (since ? `&_lastUpdated=ge${encodeURIComponent(since)}` : "");
+        let pages = 0;
+
+        while (nextUrl && pages < 500) {
+          const bundle: any = await getJSON(nextUrl, config.auth);
+          const entries: any[] = bundle.entry ?? [];
+          for (const e of entries) {
+            const res = e.resource;
+            if (!res) continue;
+            const { title, text } = flattenResource(res);
+            const json = JSON.stringify(res);
+            const sha1 = crypto.createHash("sha1").update(json).digest("hex");
+            const chunks = chunkText(text, { maxTokens: 3500, overlap: 150 });
+
+            await saveDocumentWithChunksDedup({
+              orgId, datasetId,
+              source: `${source}/${res.resourceType}/${res.id ?? crypto.randomUUID()}`,
+              title, mimeType: "application/fhir+json",
+              contentSha1: sha1, rawBytesLen: Buffer.byteLength(json),
+              sourceEtag: e.response?.etag ?? null,
+              sourceMtime: res.meta?.lastUpdated ? new Date(res.meta.lastUpdated) : null,
+              chunks
+            });
+            total++;
+          }
+
+          const nextLink = (bundle.link || []).find((l:any)=>l.relation==="next")?.url;
+          await db.query(
+            `INSERT INTO ingest_cursors (organization_id, dataset_id, source, mode, resource_types, since, resume_url, resume_next)
+             VALUES (app.get_current_org(), $1, $2, $3, $4, $5, NULL, $6)
+             ON CONFLICT (organization_id, dataset_id, source, mode) DO UPDATE SET resume_next=EXCLUDED.resume_next, updated_at=now()`,
+            [datasetId, source, "search", [rt], since ?? null, nextLink ?? null]
+          );
+          nextUrl = nextLink || null;
+          pages++;
+          await job.updateProgress(Math.min(99, pages));
+          if (!nextUrl) break;
+        }
+      }
+      const newSince = new Date().toISOString();
+      await db.query(
+        `UPDATE ingest_cursors SET since=$1, resume_next=NULL, updated_at=now() WHERE organization_id=app.get_current_org() AND dataset_id=$2 AND source=$3 AND mode='search'`,
+        [newSince, datasetId, source]
+      );
+    }
+
+    await job.updateProgress(100);
+    return { count: total };
+  });
 }
 
 async function processConnectorIngest(job: Job<AnyJob>) {
@@ -158,6 +270,8 @@ async function route(job: Job<AnyJob>) {
       return processDatasetEmbed(job);
     case "files.ingest":
       return processFilesIngest(job);
+    case "fhir.ingest":
+      return processFhirIngest(job);
     default:
       throw new Error(`Unknown job type: ${(job.data as any).type}`);
   }

--- a/tests/fhir/flatten.test.ts
+++ b/tests/fhir/flatten.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { flattenResource } from "@/connectors/fhir/flatten";
+
+describe("flattenResource", () => {
+  it("Patient", () => {
+    const { title, text } = flattenResource({
+      resourceType: "Patient",
+      id: "p1",
+      name: [{ given:["Ada"], family:"Lovelace" }],
+      gender: "female",
+      birthDate: "1815-12-10"
+    });
+    expect(title).toContain("Patient/p1");
+    expect(text).toMatch(/name:/);
+  });
+});

--- a/tests/plugins/fhir-manifest.test.ts
+++ b/tests/plugins/fhir-manifest.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { loadPlugins, listConnectors, getConnector } from "@/plugins/registry";
+
+describe("FHIR manifest", () => {
+  beforeAll(async () => { await loadPlugins(); });
+  it("registers fhir", () => {
+    const ids = listConnectors().map(c => c.spec.id);
+    expect(ids).toContain("fhir");
+  });
+  it("testConnection fails on bad URL", async () => {
+    const { create } = getConnector("fhir");
+    const c = create({ baseUrl: "https://invalid.example", auth: { kind: "none" } });
+    const ok = await c.testConnection();
+    expect(typeof ok.ok).toBe("boolean");
+  });
+});


### PR DESCRIPTION
## Summary
- implement FHIR client helpers, resource flattener and connector manifest
- add fhir.ingest job with bulk and search ingestion and resumable cursors
- expose POST /api/fhir/ingest and basic docs

## Testing
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_689b345001a8832291d8c60f02a15c43